### PR TITLE
Prepare to integrate in mapper: build in conan-builder, improve test package, simplifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,7 @@ endif()
 
 find_package(Qt5 COMPONENTS
     Core
-    Gui
-    OpenGL
-    Quick
-    Xml
-    Positioning
-    Location 
-    Network 
+    Location
     REQUIRED QUIET)
 
 set(SOURCES
@@ -29,7 +23,7 @@ set(SOURCES
    src/GeoTileFetcher.cpp
    src/GeoMapReply.cpp
    src/GeoFileTileCache.cpp
-   
+
    src/GeoServiceProviderPlugin.h
    src/GeoTiledMappingManagerEngine.h
    src/GeoTileFetcher.h
@@ -42,20 +36,12 @@ set_target_properties(${LIB_NAME} PROPERTIES AUTORCC ON AUTOMOC ON)
 
 target_link_libraries(${LIB_NAME} PRIVATE
     Qt5::Core
-    Qt5::Gui
-    Qt5::Quick
-    Qt5::Positioning
-    Qt5::Xml
     Qt5::Location
     Qt5::LocationPrivate
-    Qt5::Network
-    Qt5::OpenGL
 )
 
 target_include_directories(${LIB_NAME} INTERFACE
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-   PRIVATE src
-   ${Qt5Location_PRIVATE_INCLUDE_DIRS}
 )
 
 target_compile_features(${LIB_NAME} PRIVATE cxx_std_14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(QtBasemapPlugin VERSION 1.0.0 LANGUAGES CXX)
 
 set(LIB_NAME qtgeoservices_basemap_pix4d)

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ class QtBasemapPluginConan(ConanFile):
             # see https://github.com/conan-io/conan/issues/2856#issuecomment-421036768
             cmake.definitions["CONAN_LIBCXX"] = ""
 
-        cmake.configure(source_dir='..', build_dir='build', defs=cmake_args)
+        cmake.configure(source_dir='.', defs=cmake_args)
         cmake.build(target='install')
 
     def configure(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '1.0.1-4'
+    version = '1.0.1-5'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=5.10'
     description = 'Qt GeoServices plugin for basemaps including MapBox'

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,8 +8,6 @@ class QtBasemapPluginConan(ConanFile):
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=5.10'
     description = 'Qt GeoServices plugin for basemaps including MapBox'
-    options = {'shared': [True, False]}
-    default_options = 'shared=True'
     settings = 'os', 'compiler', 'build_type', 'arch'
     generators = 'cmake'
     exports_sources = ['CMakeLists.txt', 'src/*']
@@ -17,7 +15,7 @@ class QtBasemapPluginConan(ConanFile):
     def build(self):
         cmake = CMake(self, parallel=True)
         cmake_args = {
-            '-DBUILD_SHARED_LIBS=': 'ON' if self.options.shared else 'OFF'
+            'BUILD_SHARED_LIBS': True
         }
 
         if(tools.cross_building(self.settings) and

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,8 +29,16 @@ class QtBasemapPluginConan(ConanFile):
         cmake.configure(source_dir='.', defs=cmake_args)
         cmake.build(target='install')
 
+    def build_requirements(self):
+        self.build_requires('Qt5/[5.12.7-2]@pix4d/stable')
+
     def configure(self):
         del self.settings.compiler.libcxx
+
+    def package_id(self):
+        # Make all options and dependencies (direct and transitive) contribute
+        # to the package id
+        self.info.requires.full_package_mode()
 
     def package_info(self):
         self.cpp_info.libs = ["qtgeoservices_basemap_pix4d"]

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,10 +1,15 @@
-project(PackageTest CXX)
 cmake_minimum_required(VERSION 3.8)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_STANDARD_REQUIRED ON)
+project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_set_find_paths()
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin)
 
 find_package(Qt5 COMPONENTS
     Core
@@ -13,26 +18,10 @@ find_package(Qt5 COMPONENTS
 find_package(QtBasemapPlugin REQUIRED QUIET)
 
 add_executable(example example.cpp)
-get_property(_libFileName TARGET qtgeoservices_basemap_pix4d PROPERTY IMPORTED_LOCATION_RELEASE)
-
-if(EXISTS ${_libFileName})
-    message(STATUS "Plugin generated at: ${_libFileName}")
-else()
-    message(FATAL_ERROR "Plugin not generated at: ${_libFileName}")
-endif()
-
-if (${CMAKE_INSTALL_PREFIX} STREQUAL "")
-    set(DEPLOY_TARGET ${CMAKE_BINARY_DIR})
-else()
-    set(DEPLOY_TARGET ${CMAKE_INSTALL_PREFIX})
-endif()
-
-set(DEPLOY_TARGET ${CMAKE_BINARY_DIR})
-set(MAP_PLUGIN_DESTINATION ${DEPLOY_TARGET}/plugins/geoservices)
-set(MAP_PLUGIN ${_libFileName})
-
+get_property(MAP_PLUGIN TARGET qtgeoservices_basemap_pix4d PROPERTY IMPORTED_LOCATION_RELEASE)
 message(STATUS "Map plugin path ${MAP_PLUGIN}")
 
+set(MAP_PLUGIN_DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/plugins/geoservices)
 file(MAKE_DIRECTORY ${MAP_PLUGIN_DESTINATION})
 file(COPY ${MAP_PLUGIN} DESTINATION ${MAP_PLUGIN_DESTINATION})
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,9 +4,13 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_STANDARD_REQUIRED ON)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_set_find_paths()
 
-find_package(QtBasemapPlugin)
+find_package(Qt5 COMPONENTS
+    Core
+    Location
+    REQUIRED QUIET)
+find_package(QtBasemapPlugin REQUIRED QUIET)
 
 add_executable(example example.cpp)
 get_property(_libFileName TARGET qtgeoservices_basemap_pix4d PROPERTY IMPORTED_LOCATION_RELEASE)
@@ -24,7 +28,7 @@ else()
 endif()
 
 set(DEPLOY_TARGET ${CMAKE_BINARY_DIR})
-set(MAP_PLUGIN_DESTINATION ${DEPLOY_TARGET}/Plugins/geoservices)
+set(MAP_PLUGIN_DESTINATION ${DEPLOY_TARGET}/plugins/geoservices)
 set(MAP_PLUGIN ${_libFileName})
 
 message(STATUS "Map plugin path ${MAP_PLUGIN}")
@@ -32,9 +36,12 @@ message(STATUS "Map plugin path ${MAP_PLUGIN}")
 file(MAKE_DIRECTORY ${MAP_PLUGIN_DESTINATION})
 file(COPY ${MAP_PLUGIN} DESTINATION ${MAP_PLUGIN_DESTINATION})
 
-
+target_link_libraries(example PRIVATE
+    Qt5::Core
+    Qt5::Location
+)
 # don't link with it because this is needed only by the Qt runtime to give a full path to the folder containing it
 #target_link_libraries(example PRIVATE
 #    qtgeoservices_basemap_pix4d
 #)
-            
+

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -6,15 +6,13 @@ class QtBasemapPluginTestConan(ConanFile):
     generators = 'cmake'
 
     def build(self):
-        cmake = CMake(self)
-        cmake.configure(source_dir=self.conanfile_directory, build_dir='./')
+        cmake = CMake(self, parallel=True)
+        cmake.configure(build_dir='./')
         cmake.build()
+        # Note: Not running from the install target to avoid packaging qt properly
 
-    def imports(self):
-        self.copy('*.dll', dst='bin', src='x64/vc15/bin')
-        self.copy('*.dylib*', dst='lib', src='lib')
-        self.copy('*.so*', dst='bin', src='lib')
+    def requirements(self):
+        self.requires('Qt5/[5.12.7-2]@pix4d/stable')
 
     def test(self):
-        os.chdir('bin')
-        self.run('.%sexample' % os.sep)
+        self.run(os.path.join('bin', 'example'))

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,3 +1,25 @@
-int main() {
-    return 0; 
+#include <QCoreApplication>
+#include <QGeoServiceProvider>
+
+#include <iostream>
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    QCoreApplication::addLibraryPath(QCoreApplication::applicationDirPath() + "/plugins");
+    if (!QGeoServiceProvider::availableServiceProviders().contains(QStringLiteral("basemap_pix4d"), Qt::CaseInsensitive))
+    {
+        std::cout << "ERROR locating plugin!" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    QGeoServiceProvider plugin("basemap_pix4d");
+    if (plugin.error())
+    {
+        std::cout << "ERROR loading plugin!" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Plugin available" << std::endl;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR addresses https://pix4dbug.atlassian.net/browse/MAPPER-9009, part of https://pix4dbug.atlassian.net/browse/MAPPER-8948. The simplest solution we found to use the new Mapbox API is to reuse this plugin in mapper :)

These are some improvements, aimed at allowing building a controlled environment (conan-builder) and improving the test_package to show how to use the plugin.

List of changes in this PR:
 * Adapted to make it compile in the conan-builder: https://github.com/Pix4D/conan-builder/pull/277. Mostly declaring dependencies where needed.
 * Added a more complete test_package that shows that the compiled plugin can be found and loaded by Qt.
 * Removed shared option because it was not working (is this OK? does anybody use it?)
 * Some simplifications

Successful build in conan-builder: https://github.com/Pix4D/conan-builder/pull/277 https://builder.ci.pix4d.com/teams/developers/pipelines/conan-builder-MAPPER-8948-updateMapboxPlugin/jobs/qtBasemapPlugin/builds/7
Successful integration in mapper: https://github.com/Pix4D/pix4d-mapper/pull/109 https://builder.ci.pix4d.com/teams/developers/pipelines/mapper-MAPPER-8948-updateMapboxPlugin

As this is a plugin loaded at runtime it is a bit different from other conan recipes.

It would be nice to review the name of the conan package/cmake targets/repo name to make them consistent (but not in this PR).