### PR TITLE
Make custom basemap option of of the map types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+
+## QtBasemapPlugin 1.1.0-1
+
+### Added
+- new "Custom"-MapType option which fetches map tiles from a custom url. When [Map QML Type](https://doc.qt.io/qt-5/qml-qtlocation-map.html) is used,
+the new map type can be chosen as [activeMapType](https://doc.qt.io/qt-5/qml-qtlocation-map.html#activeMapType-prop).
+
+### Changed
+- if [plugin](https://doc.qt.io/qt-5/qml-qtlocation-plugin.html) is instantiated with custom url parameter, the switch between Satellite, Street (provided by mapbox) 
+and Custom tiles (provided via custom basemap url) can be done without plugin [reinstantiation](https://doc.qt.io/qt-5/qml-qtlocation-map.html#plugin-prop)
+

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '1.0.1-4'
+    version = '1.1.0-1'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=5.10'
     description = 'Qt GeoServices plugin for basemaps including MapBox'

--- a/src/GeoFileTileCache.cpp
+++ b/src/GeoFileTileCache.cpp
@@ -16,7 +16,7 @@ GeoFileTileCache::GeoFileTileCache(const QList<QGeoMapType>& mapTypes,
     m_scaleFactor = qBound(1, scaleFactor, 2);
     for (int i = 0; i < mapTypes.size(); i++)
     {
-        m_mapNameToId.insert(mapTypes[i].name(), i + 1);
+        m_mapNameToId.insert(mapTypes[i].name(), i);
     }
 }
 
@@ -32,7 +32,7 @@ QString GeoFileTileCache::tileSpecToFilename(const QGeoTileSpec& spec,
     QString filename = spec.plugin();
 
     filename += QLatin1String("-");
-    filename += m_mapTypes[spec.mapId() - 1].name();
+    filename += m_mapTypes[spec.mapId()].name();
     filename += QLatin1String("-");
     filename += QString::number(spec.zoom());
     filename += QLatin1String("-");

--- a/src/GeoTileFetcher.h
+++ b/src/GeoTileFetcher.h
@@ -21,9 +21,12 @@ private:
     QGeoTiledMapReply* getTileImage(const QGeoTileSpec& spec);
 
 public:
-    // The list of map style ids
+    // The list of map style names:
+    // The two values below are part of url allowing to fetch corresponsing mapbox tiles
     static constexpr const char* PIX4D_STREET = "ck8zz9gpq0vty1ip30bji3b5a";
     static constexpr const char* PIX4D_STREETS_SATELLITE = "ck8zzfxb30vwp1jo04yktjtbg";
+    // name for custom basemap tiles requests
+    static constexpr const char* PIX4D_CUSTOM = "custom";
 
 private:
     QNetworkAccessManager* m_networkManager{nullptr};


### PR DESCRIPTION
The PR enables new "Custom"-MapType option for the plugin. For RAG project that means that switching to custom basemap does not require a re-instantiation of a qml component which configures plugin.

I used separate branch, which is branched out of `master` on tag "1.0.1-4", because current RAG release does not use conan Qt-dependency. For next releases (which will use "normal" conan workflow), I will cherry-pick commits between tag "1.0.1-4" and "1.0.1-5" onto `stable/1.1.0`-branch