### PR TITLE
[RAG-9105]: Street map tiles are not loaded correctly from cache

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '2.0.0-7'
+    version = '2.0.0-8'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.6.3'
     description = 'Qt GeoServices plugin for basemaps including MapBox'

--- a/src/qgeofiletilecachemapbox.cpp
+++ b/src/qgeofiletilecachemapbox.cpp
@@ -17,7 +17,7 @@ QGeoFileTileCacheMapbox::QGeoFileTileCacheMapbox(const QList<QGeoMapType> &mapTy
 {
     m_scaleFactor = qBound(1, scaleFactor, 2);
     for (qsizetype i = 0; i < mapTypes.size(); i++)
-        m_mapNameToId.insert(mapTypes[i].name(), i + 1);
+        m_mapNameToId.insert(mapTypes[i].name(), i);
 }
 
 QGeoFileTileCacheMapbox::~QGeoFileTileCacheMapbox()


### PR DESCRIPTION
[RAG-9105](https://pix4dbug.atlassian.net/browse/RAG-9105) - Street map tiles are not loaded correctly from cache

[RAG-9105]: https://pix4dbug.atlassian.net/browse/RAG-9105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ