### PR TITLE
RAG-9416: Remove implemented Mapbox style, use direct URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Add any directories, files, or patterns you don't want to be tracked by version control
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and Custom tiles (provided via custom basemap url) can be done without plugin [r
 - QtBasemapPlugin is being upgraded and based on Qt 6.7.1-0
 
 
-## QtBasemapPlugin 2.1.0-0
+## QtBasemapPlugin 2.0.0-11
 
 ### Added
 - MapTiler satellite and streets map tile URLs as default map styles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and Custom tiles (provided via custom basemap url) can be done without plugin [r
 
 ### Added
 - MapTiler satellite and streets map tile URLs as default map styles
+- Set additional parameters to the URL query items
 
 ### Removed
 - MapBox default tile URLs in QGeoTileFetcherMapbox
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,25 @@ and Custom tiles (provided via custom basemap url) can be done without plugin [r
 
 ### Changed
 - QtBasemapPlugin is being upgraded and based on Qt 6.6.0-1 now.
+
+
+## QtBasemapPlugin 2.0.0-9
+
+### Changed
+- QtBasemapPlugin is being upgraded and based on Qt 6.7.0-0
+
+
+## QtBasemapPlugin 2.0.0-10
+
+### Changed
+- QtBasemapPlugin is being upgraded and based on Qt 6.7.1-0
+
+
+## QtBasemapPlugin 2.1.0-0
+
+### Added
+- MapTiler satellite and streets map tile URLs as default map styles
+
+### Removed
+- MapBox default tile URLs in QGeoTileFetcherMapbox
+

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '2.1.0-0'
+    version = '2.0.0-11'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.7.1'
     description = 'Qt GeoServices plugin for basemaps including MapBox'

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '2.0.0-10'
+    version = '2.1.0-0'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.7.1'
     description = 'Qt GeoServices plugin for basemaps including MapBox'

--- a/src/qgeotiledmappingmanagerenginemapbox.cpp
+++ b/src/qgeotiledmappingmanagerenginemapbox.cpp
@@ -134,26 +134,6 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     {
         tileFetcher->setFormat(format);
     }
-    
-    QString satelliteUrl;
-    if (getParameter(parameters, "satellite_url", satelliteUrl))
-    {
-        tileFetcher->setSatelliteUrl(satelliteUrl);
-    }
-    else
-    {
-        qCritical() << "Basemap Plugin no satellite URL was set";
-    }
-    
-    QString streetsUtl;
-    if (getParameter(parameters, "streets_url", streetsUtl))
-    {
-        tileFetcher->setStreetsUrl(streetsUtl);
-    }
-    else
-    {
-        qCritical() << "Basemap Plugin no streets URL was set";
-    }
 
     setTileFetcher(tileFetcher);
 

--- a/src/qgeotiledmappingmanagerenginemapbox.cpp
+++ b/src/qgeotiledmappingmanagerenginemapbox.cpp
@@ -72,7 +72,7 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
 
     QList<QGeoMapType> mapTypes;
     mapTypes << QGeoMapType(QGeoMapType::SatelliteMapDay,
-                            QGeoTileFetcherMapbox::PIX4D_STREETS_SATELLITE,
+                            QGeoTileFetcherMapbox::PIX4D_SATELLITE,
                             QStringLiteral("Satellite"),
                             false,
                             false,
@@ -80,8 +80,8 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
                             pluginName,
                             cameraCaps);
     mapTypes << QGeoMapType(QGeoMapType::StreetMap,
-                            QGeoTileFetcherMapbox::PIX4D_STREET,
-                            QStringLiteral("Street"),
+                            QGeoTileFetcherMapbox::PIX4D_STREETS,
+                            QStringLiteral("Streets"),
                             false,
                             false,
                             mapTypes.size(),
@@ -92,7 +92,7 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     getParameter(parameters, "custom_basemap_url", customBasemapUrl);
     if (!customBasemapUrl.isEmpty())
         mapTypes << QGeoMapType(QGeoMapType::CustomMap,
-                                "custom",
+                                QGeoTileFetcherMapbox::PIX4D_CUSTOM,
                                 QStringLiteral("Custom"),
                                 false,
                                 false,
@@ -134,15 +134,25 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     {
         tileFetcher->setFormat(format);
     }
-
-    QString accessToken;
-    if (getParameter(parameters, "access_token", accessToken))
+    
+    QString satelliteUrl;
+    if (getParameter(parameters, "satellite_url", satelliteUrl))
     {
-        tileFetcher->setAccessToken(accessToken);
+        tileFetcher->setSatelliteUrl(satelliteUrl);
     }
     else
     {
-        qCritical() << "Basemap Plugin no access token was set";
+        qCritical() << "Basemap Plugin no satellite URL was set";
+    }
+    
+    QString streetsUtl;
+    if (getParameter(parameters, "streets_url", streetsUtl))
+    {
+        tileFetcher->setStreetsUrl(streetsUtl);
+    }
+    else
+    {
+        qCritical() << "Basemap Plugin no streets URL was set";
     }
 
     setTileFetcher(tileFetcher);

--- a/src/qgeotiledmappingmanagerenginemapbox.cpp
+++ b/src/qgeotiledmappingmanagerenginemapbox.cpp
@@ -134,7 +134,8 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     {
         tileFetcher->setFormat(format);
     }
-
+    
+    tileFetcher->setAdditionalParameters(parameters);
     setTileFetcher(tileFetcher);
 
     if (customBasemapUrl.isEmpty())

--- a/src/qgeotilefetchermapbox.cpp
+++ b/src/qgeotilefetchermapbox.cpp
@@ -148,16 +148,6 @@ void QGeoTileFetcherMapbox::setFormat(const QString &format)
         qWarning() << "Unknown map format " << m_format;
 }
 
-void QGeoTileFetcherMapbox::setSatelliteUrl(const QString &satelliteUrl)
-{
-    m_satelliteUrl = satelliteUrl;
-}
-
-void QGeoTileFetcherMapbox::setStreetsUrl(const QString &streetsUrl)
-{
-    m_streetsUrl = streetsUrl;
-}
-
 QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
 {
     QNetworkRequest request;
@@ -171,12 +161,14 @@ QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
     QStringList subdomains;
     
     QString basemapUrl;
-    if ((spec.mapId() < m_mapIds.size()) && !m_customBasemapUrl.isEmpty() && (m_mapIds[spec.mapId()] == PIX4D_CUSTOM))
+    const bool isCustomBasemapRequest = (spec.mapId() < m_mapIds.size()) && !m_customBasemapUrl.isEmpty() && (m_mapIds[spec.mapId()] == PIX4D_CUSTOM);
+    if (isCustomBasemapRequest)
         basemapUrl = m_customBasemapUrl;
     else if (m_mapIds[spec.mapId()] == PIX4D_STREETS)
-        basemapUrl = m_streetsUrl;
-    else if (m_mapIds[spec.mapId()] == PIX4D_SATELLITE)
-        basemapUrl = m_satelliteUrl;
+        basemapUrl = MAPTILER_STREETS_URL;
+    else // if (m_mapIds[spec.mapId()] == PIX4D_SATELLITE)
+        basemapUrl = MAPTILER_SATELLITE_URL;
+
     basemapUrl = basemapUrl.replace("{x}", x);
     basemapUrl = basemapUrl.replace("{y}", y);
     basemapUrl = basemapUrl.replace("{z}", z);

--- a/src/qgeotilefetchermapbox.cpp
+++ b/src/qgeotilefetchermapbox.cpp
@@ -120,7 +120,6 @@ QGeoTileFetcherMapbox::QGeoTileFetcherMapbox(int scaleFactor, bool enableLogging
     m_userAgent(mapboxDefaultUserAgent),
     m_format("png"),
     m_replyFormat("png"),
-    m_accessToken(""),
     m_enableLogging(enableLogging),
     m_customBasemapUrl(customBasemapUrl)
 {
@@ -149,9 +148,14 @@ void QGeoTileFetcherMapbox::setFormat(const QString &format)
         qWarning() << "Unknown map format " << m_format;
 }
 
-void QGeoTileFetcherMapbox::setAccessToken(const QString &accessToken)
+void QGeoTileFetcherMapbox::setSatelliteUrl(const QString &satelliteUrl)
 {
-    m_accessToken = accessToken;
+    m_satelliteUrl = satelliteUrl;
+}
+
+void QGeoTileFetcherMapbox::setStreetsUrl(const QString &streetsUrl)
+{
+    m_streetsUrl = streetsUrl;
 }
 
 QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
@@ -159,123 +163,107 @@ QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
     QNetworkRequest request;
     request.setRawHeader("User-Agent", m_userAgent);
 
-    const bool isCustomBasemapRequest = (spec.mapId() < m_mapIds.size()) && !m_customBasemapUrl.isEmpty() && (m_mapIds[spec.mapId()] == PIX4D_CUSTOM);
-
     QUrl tileUrl;
-    if (!isCustomBasemapRequest)
+    const QString x = QString::number(spec.x());
+    const QString y = QString::number(spec.y());
+    const QString z = QString::number(spec.zoom());
+    QString q, r, bbox, invY, wmsVersion;
+    QStringList subdomains;
+    
+    QString basemapUrl;
+    if ((spec.mapId() < m_mapIds.size()) && !m_customBasemapUrl.isEmpty() && (m_mapIds[spec.mapId()] == PIX4D_CUSTOM))
+        basemapUrl = m_customBasemapUrl;
+    else if (m_mapIds[spec.mapId()] == PIX4D_STREETS)
+        basemapUrl = m_streetsUrl;
+    else if (m_mapIds[spec.mapId()] == PIX4D_SATELLITE)
+        basemapUrl = m_satelliteUrl;
+    basemapUrl = basemapUrl.replace("{x}", x);
+    basemapUrl = basemapUrl.replace("{y}", y);
+    basemapUrl = basemapUrl.replace("{z}", z);
+    basemapUrl = basemapUrl.replace("{s}", "{sabc}");
+
+    if (basemapUrl.contains("{-y}"))
     {
-        tileUrl = QUrl(QStringLiteral("https://api.mapbox.com/styles/v1/cloudpix4d/")
-                + ((spec.mapId() >= m_mapIds.size()) ? PIX4D_STREET : m_mapIds[spec.mapId()])
-                + QLatin1String("/tiles/256/")
-                + QString::number(spec.zoom())
-                + QLatin1Char('/')
-                + QString::number(spec.x())
-                + QLatin1Char('/')
-                + QString::number(spec.y())
-                + ((m_scaleFactor > 1) ? (QLatin1Char('@') + QString::number(m_scaleFactor) + QLatin1Char('x')) : QString())
-                + QLatin1Char('?')
-                + QStringLiteral("access_token=")
-                + m_accessToken);
-    }
-    else
-    {
-        const QString x = QString::number(spec.x());
-        const QString y = QString::number(spec.y());
-        const QString z = QString::number(spec.zoom());
-        QString q, r, bbox, invY, wmsVersion;
-        QStringList subdomains;
-
-        auto basemapUrl = m_customBasemapUrl;
-        basemapUrl = basemapUrl.replace("{x}", x);
-        basemapUrl = basemapUrl.replace("{y}", y);
-        basemapUrl = basemapUrl.replace("{z}", z);
-        basemapUrl = basemapUrl.replace("{s}", "{sabc}");
-
-        if (basemapUrl.contains("{-y}"))
-        {
-            invY = QString::number((1 << spec.zoom()) - spec.y() - 1);
-            basemapUrl = basemapUrl.replace("{-y}", invY);
-        }
-
-        if (basemapUrl.contains("{q}"))
-        {
-            q = tileToQuad(spec);
-            basemapUrl = basemapUrl.replace("{q}", q);
-        }
-
-        if (basemapUrl.contains("{r}"))
-        {
-            r = m_scaleFactor > 1 ? QLatin1Char('@') + QString::number(m_scaleFactor) + QLatin1String("x") : "";
-            basemapUrl = basemapUrl.replace("{r}", r);
-        }
-
-        if (basemapUrl.contains("{bbox4326}"))
-        {
-            // Version 1.3 and higher of WMS urls uses latitude first
-            const int versionIndex = basemapUrl.toLower().indexOf("version=");
-            wmsVersion = versionIndex >= 0 ? basemapUrl.mid(versionIndex + 8, 3) : "0.0";
-            bbox = bbox4326ToString(spec, wmsVersion.toDouble() < 1.3);
-            basemapUrl = basemapUrl.replace("{bbox4326}", bbox);
-        }
-        else if (basemapUrl.contains("{bbox4326_lonlat}"))
-        {
-            bbox = bbox4326ToString(spec, true);
-            basemapUrl = basemapUrl.replace("{bbox4326_lonlat}", bbox);
-        }
-        else if (basemapUrl.contains("{bbox4326_latlon}"))
-        {
-            bbox = bbox4326ToString(spec, false);
-            basemapUrl = basemapUrl.replace("{bbox4326_latlon}", bbox);
-        }
-        else if (basemapUrl.contains("{bbox3857}"))
-        {
-            bbox = bbox3857ToString(spec);
-            basemapUrl = basemapUrl.replace("{bbox3857}", bbox);
-        }
-
-        int startIndex = basemapUrl.indexOf(QLatin1String("{s"));
-        while (startIndex != -1)
-        {
-            const int endIndex = basemapUrl.indexOf(QLatin1Char('}'), startIndex);
-            if (endIndex != -1)
-            {
-                const int count = endIndex - startIndex + 1;
-                const auto value = basemapUrl.mid(startIndex + 2, std::max(count - 3, 0));
-                subdomains.push_back(replaceSubdomain(spec, value));
-                basemapUrl.replace(startIndex, count, subdomains.back());
-                startIndex = basemapUrl.indexOf(QLatin1String("{s"));
-            }
-            else
-            {
-                if (m_enableLogging)
-                {
-                    qCritical() << "Basemap custom URL invalid {";
-                }
-                break;
-            }
-        }
-
-        if (m_enableLogging)
-        {
-            const QString provider = QUrl(basemapUrl).host();
-            QString urlDetails = provider +
-                " {x}=" + x +
-                " {y}=" + y +
-                " {z}=" + z +
-                (!q.isEmpty() ? " {q}=" + q : "") +
-                (!r.isEmpty() ? " {r}=" + r : "") +
-                (!invY.isEmpty() ? " {-y}=" + invY : "") +
-                (!subdomains.isEmpty() ? " {s}=" + subdomains.join(", ") : "") +
-                (!bbox.isEmpty() ? " {bbox}=" + bbox : "") +
-                (!wmsVersion.isEmpty() ? " with version " + wmsVersion : "");
-            qInfo() << "Basemap tile requested" << urlDetails;
-        }
-
-        tileUrl = QUrl(basemapUrl);
+        invY = QString::number((1 << spec.zoom()) - spec.y() - 1);
+        basemapUrl = basemapUrl.replace("{-y}", invY);
     }
 
+    if (basemapUrl.contains("{q}"))
+    {
+        q = tileToQuad(spec);
+        basemapUrl = basemapUrl.replace("{q}", q);
+    }
+
+    if (basemapUrl.contains("{r}"))
+    {
+        r = m_scaleFactor > 1 ? QLatin1Char('@') + QString::number(m_scaleFactor) + QLatin1String("x") : "";
+        basemapUrl = basemapUrl.replace("{r}", r);
+    }
+
+    if (basemapUrl.contains("{bbox4326}"))
+    {
+        // Version 1.3 and higher of WMS urls uses latitude first
+        const int versionIndex = basemapUrl.toLower().indexOf("version=");
+        wmsVersion = versionIndex >= 0 ? basemapUrl.mid(versionIndex + 8, 3) : "0.0";
+        bbox = bbox4326ToString(spec, wmsVersion.toDouble() < 1.3);
+        basemapUrl = basemapUrl.replace("{bbox4326}", bbox);
+    }
+    else if (basemapUrl.contains("{bbox4326_lonlat}"))
+    {
+        bbox = bbox4326ToString(spec, true);
+        basemapUrl = basemapUrl.replace("{bbox4326_lonlat}", bbox);
+    }
+    else if (basemapUrl.contains("{bbox4326_latlon}"))
+    {
+        bbox = bbox4326ToString(spec, false);
+        basemapUrl = basemapUrl.replace("{bbox4326_latlon}", bbox);
+    }
+    else if (basemapUrl.contains("{bbox3857}"))
+    {
+        bbox = bbox3857ToString(spec);
+        basemapUrl = basemapUrl.replace("{bbox3857}", bbox);
+    }
+
+    int startIndex = basemapUrl.indexOf(QLatin1String("{s"));
+    while (startIndex != -1)
+    {
+        const int endIndex = basemapUrl.indexOf(QLatin1Char('}'), startIndex);
+        if (endIndex != -1)
+        {
+            const int count = endIndex - startIndex + 1;
+            const auto value = basemapUrl.mid(startIndex + 2, std::max(count - 3, 0));
+            subdomains.push_back(replaceSubdomain(spec, value));
+            basemapUrl.replace(startIndex, count, subdomains.back());
+            startIndex = basemapUrl.indexOf(QLatin1String("{s"));
+        }
+        else
+        {
+            if (m_enableLogging)
+            {
+                qCritical() << "Basemap custom URL invalid {";
+            }
+            break;
+        }
+    }
+
+    if (m_enableLogging)
+    {
+        const QString provider = QUrl(basemapUrl).host();
+        QString urlDetails = provider +
+            " {x}=" + x +
+            " {y}=" + y +
+            " {z}=" + z +
+            (!q.isEmpty() ? " {q}=" + q : "") +
+            (!r.isEmpty() ? " {r}=" + r : "") +
+            (!invY.isEmpty() ? " {-y}=" + invY : "") +
+            (!subdomains.isEmpty() ? " {s}=" + subdomains.join(", ") : "") +
+            (!bbox.isEmpty() ? " {bbox}=" + bbox : "") +
+            (!wmsVersion.isEmpty() ? " with version " + wmsVersion : "");
+        qInfo() << "Basemap tile requested" << urlDetails;
+    }
+
+    tileUrl = QUrl(basemapUrl);
     request.setUrl(tileUrl);
-
     return new QGeoMapReplyMapbox(m_networkManager->get(request), spec, m_replyFormat, m_enableLogging);
 }
 

--- a/src/qgeotilefetchermapbox.cpp
+++ b/src/qgeotilefetchermapbox.cpp
@@ -148,6 +148,18 @@ void QGeoTileFetcherMapbox::setFormat(const QString &format)
         qWarning() << "Unknown map format " << m_format;
 }
 
+void QGeoTileFetcherMapbox::setAdditionalParameters(const QVariantMap& parameters)
+{
+    std::for_each(parameters.keyBegin(), parameters.keyEnd(), [this, parameters](const auto& inputKey){
+        if (std::none_of(NON_QUERY_PARAMETER_KEYS.cbegin(), NON_QUERY_PARAMETER_KEYS.cend(), [this, inputKey](const QString& key){
+            return inputKey == key;
+            }))
+        {
+            m_query.addQueryItem(inputKey, parameters[inputKey].toString());
+        }
+    });
+}
+
 QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
 {
     QNetworkRequest request;
@@ -255,6 +267,10 @@ QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
     }
 
     tileUrl = QUrl(basemapUrl);
+    
+    if (!m_query.isEmpty())
+        tileUrl.setQuery(m_query);
+
     request.setUrl(tileUrl);
     return new QGeoMapReplyMapbox(m_networkManager->get(request), spec, m_replyFormat, m_enableLogging);
 }

--- a/src/qgeotilefetchermapbox.h
+++ b/src/qgeotilefetchermapbox.h
@@ -18,11 +18,9 @@ class QGeoTileFetcherMapbox : public QGeoTileFetcher
 
 public:
     // The list of map style names:
-    // The two values below are part of url allowing to fetch corresponsing mapbox tiles
-    static constexpr const char* PIX4D_STREET = "ck8zz9gpq0vty1ip30bji3b5a";
-    static constexpr const char* PIX4D_STREETS_SATELLITE = "ck8zzfxb30vwp1jo04yktjtbg";
-    // name for custom basemap tiles requests
-    static constexpr const char* PIX4D_CUSTOM = "custom";
+    static constexpr const char* PIX4D_STREETS = "Streets";
+    static constexpr const char* PIX4D_SATELLITE = "Satellite";
+    static constexpr const char* PIX4D_CUSTOM = "Custom";
 
 public:
     QGeoTileFetcherMapbox(int scaleFactor, bool enableLogging, const QString& customBasemapUrl, QGeoTiledMappingManagerEngine *parent);
@@ -30,7 +28,8 @@ public:
     void setUserAgent(const QByteArray &userAgent);
     void setMapIds(const QList<QString> &mapIds);
     void setFormat(const QString &format);
-    void setAccessToken(const QString &accessToken);
+    void setSatelliteUrl(const QString &satelliteUrl);
+    void setStreetsUrl(const QString &streetsUrl);
 
 private:
     QGeoTiledMapReply *getTileImage(const QGeoTileSpec &spec) override;
@@ -39,7 +38,8 @@ private:
     QByteArray m_userAgent;
     QString m_format;
     QString m_replyFormat;
-    QString m_accessToken;
+    QString m_satelliteUrl;
+    QString m_streetsUrl;
     QList<QString> m_mapIds;
     int m_scaleFactor;
     bool m_enableLogging{false};

--- a/src/qgeotilefetchermapbox.h
+++ b/src/qgeotilefetchermapbox.h
@@ -28,8 +28,6 @@ public:
     void setUserAgent(const QByteArray &userAgent);
     void setMapIds(const QList<QString> &mapIds);
     void setFormat(const QString &format);
-    void setSatelliteUrl(const QString &satelliteUrl);
-    void setStreetsUrl(const QString &streetsUrl);
 
 private:
     QGeoTiledMapReply *getTileImage(const QGeoTileSpec &spec) override;
@@ -38,8 +36,6 @@ private:
     QByteArray m_userAgent;
     QString m_format;
     QString m_replyFormat;
-    QString m_satelliteUrl;
-    QString m_streetsUrl;
     QList<QString> m_mapIds;
     int m_scaleFactor;
     bool m_enableLogging{false};

--- a/src/qgeotilefetchermapbox.h
+++ b/src/qgeotilefetchermapbox.h
@@ -6,6 +6,7 @@
 
 #include <qlist.h>
 #include <QtLocation/private/qgeotilefetcher_p.h>
+#include <QUrlQuery>
 
 QT_BEGIN_NAMESPACE
 
@@ -28,6 +29,7 @@ public:
     void setUserAgent(const QByteArray &userAgent);
     void setMapIds(const QList<QString> &mapIds);
     void setFormat(const QString &format);
+    void setAdditionalParameters(const QVariantMap& parameters);
 
 private:
     QGeoTiledMapReply *getTileImage(const QGeoTileSpec &spec) override;
@@ -40,6 +42,7 @@ private:
     int m_scaleFactor;
     bool m_enableLogging{false};
     QString m_customBasemapUrl;
+    QUrlQuery m_query;
 };
 
 QT_END_NAMESPACE

--- a/src/qmapboxcommon.h
+++ b/src/qmapboxcommon.h
@@ -10,6 +10,9 @@
 
 QT_BEGIN_NAMESPACE
 
+static const QString MAPTILER_SATELLITE_URL = QStringLiteral("https://api.maptiler.com/maps/hybrid/{z}/{x}/{y}.jpg");
+static const QString MAPTILER_STREETS_URL = QStringLiteral("https://api.maptiler.com/maps/streets-v2/{z}/{x}/{y}.png");
+
 static const QString mapboxTilesApiPath = QStringLiteral("http://api.tiles.mapbox.com/v4/");
 
 // https://www.mapbox.com/api-documentation/#geocoding

--- a/src/qmapboxcommon.h
+++ b/src/qmapboxcommon.h
@@ -26,6 +26,16 @@ static const QByteArray mapboxDefaultUserAgent = QByteArrayLiteral("Qt Location 
 
 static const qreal mapboxDefaultRadius = 50000;
 
+const QStringList NON_QUERY_PARAMETER_KEYS{QStringLiteral("enable_logging"),
+    QStringLiteral("maximum_zoom_level"),
+    QStringLiteral("no_map_tiles"),
+    QStringLiteral("custom_basemap_url"),
+    QStringLiteral("highdpi_tiles"),
+    QStringLiteral("useragent"),
+    QStringLiteral("format"),
+    QStringLiteral("cache_directory"),
+};
+
 class QMapboxCommon
 {
 public:


### PR DESCRIPTION
To use Maptiler, we need to use direct URLs as default styles instead of the implemented Mapbox style.
Removed Mapbox style related part in the `QGeoTileFetcherMapbox::getTileImage()` function, and it will use MapTiler style URLs for default styles.