### PR TITLE
Revert "RAG-9416: Remove implemented Mapbox style, use direct URLs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Add any directories, files, or patterns you don't want to be tracked by version control
-.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,25 +36,3 @@ and Custom tiles (provided via custom basemap url) can be done without plugin [r
 
 ### Changed
 - QtBasemapPlugin is being upgraded and based on Qt 6.6.0-1 now.
-
-
-## QtBasemapPlugin 2.0.0-9
-
-### Changed
-- QtBasemapPlugin is being upgraded and based on Qt 6.7.0-0
-
-
-## QtBasemapPlugin 2.0.0-10
-
-### Changed
-- QtBasemapPlugin is being upgraded and based on Qt 6.7.1-0
-
-
-## QtBasemapPlugin 2.0.0-11
-
-### Added
-- MapTiler satellite and streets map tile URLs as default map styles
-- Set additional parameters to the URL query items
-
-### Removed
-- MapBox default tile URLs in QGeoTileFetcherMapbox

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '2.0.0-11'
+    version = '2.0.0-10'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.7.1'
     description = 'Qt GeoServices plugin for basemaps including MapBox'

--- a/src/qgeotiledmappingmanagerenginemapbox.cpp
+++ b/src/qgeotiledmappingmanagerenginemapbox.cpp
@@ -72,7 +72,7 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
 
     QList<QGeoMapType> mapTypes;
     mapTypes << QGeoMapType(QGeoMapType::SatelliteMapDay,
-                            QGeoTileFetcherMapbox::PIX4D_SATELLITE,
+                            QGeoTileFetcherMapbox::PIX4D_STREETS_SATELLITE,
                             QStringLiteral("Satellite"),
                             false,
                             false,
@@ -80,8 +80,8 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
                             pluginName,
                             cameraCaps);
     mapTypes << QGeoMapType(QGeoMapType::StreetMap,
-                            QGeoTileFetcherMapbox::PIX4D_STREETS,
-                            QStringLiteral("Streets"),
+                            QGeoTileFetcherMapbox::PIX4D_STREET,
+                            QStringLiteral("Street"),
                             false,
                             false,
                             mapTypes.size(),
@@ -92,7 +92,7 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     getParameter(parameters, "custom_basemap_url", customBasemapUrl);
     if (!customBasemapUrl.isEmpty())
         mapTypes << QGeoMapType(QGeoMapType::CustomMap,
-                                QGeoTileFetcherMapbox::PIX4D_CUSTOM,
+                                "custom",
                                 QStringLiteral("Custom"),
                                 false,
                                 false,
@@ -134,8 +134,17 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     {
         tileFetcher->setFormat(format);
     }
-    
-    tileFetcher->setAdditionalParameters(parameters);
+
+    QString accessToken;
+    if (getParameter(parameters, "access_token", accessToken))
+    {
+        tileFetcher->setAccessToken(accessToken);
+    }
+    else
+    {
+        qCritical() << "Basemap Plugin no access token was set";
+    }
+
     setTileFetcher(tileFetcher);
 
     if (customBasemapUrl.isEmpty())

--- a/src/qgeotilefetchermapbox.cpp
+++ b/src/qgeotilefetchermapbox.cpp
@@ -120,6 +120,7 @@ QGeoTileFetcherMapbox::QGeoTileFetcherMapbox(int scaleFactor, bool enableLogging
     m_userAgent(mapboxDefaultUserAgent),
     m_format("png"),
     m_replyFormat("png"),
+    m_accessToken(""),
     m_enableLogging(enableLogging),
     m_customBasemapUrl(customBasemapUrl)
 {
@@ -148,16 +149,9 @@ void QGeoTileFetcherMapbox::setFormat(const QString &format)
         qWarning() << "Unknown map format " << m_format;
 }
 
-void QGeoTileFetcherMapbox::setAdditionalParameters(const QVariantMap& parameters)
+void QGeoTileFetcherMapbox::setAccessToken(const QString &accessToken)
 {
-    std::for_each(parameters.keyBegin(), parameters.keyEnd(), [this, parameters](const auto& inputKey){
-        if (std::none_of(NON_QUERY_PARAMETER_KEYS.cbegin(), NON_QUERY_PARAMETER_KEYS.cend(), [this, inputKey](const QString& key){
-            return inputKey == key;
-            }))
-        {
-            m_query.addQueryItem(inputKey, parameters[inputKey].toString());
-        }
-    });
+    m_accessToken = accessToken;
 }
 
 QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
@@ -165,113 +159,123 @@ QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
     QNetworkRequest request;
     request.setRawHeader("User-Agent", m_userAgent);
 
-    QUrl tileUrl;
-    const QString x = QString::number(spec.x());
-    const QString y = QString::number(spec.y());
-    const QString z = QString::number(spec.zoom());
-    QString q, r, bbox, invY, wmsVersion;
-    QStringList subdomains;
-    
-    QString basemapUrl;
     const bool isCustomBasemapRequest = (spec.mapId() < m_mapIds.size()) && !m_customBasemapUrl.isEmpty() && (m_mapIds[spec.mapId()] == PIX4D_CUSTOM);
-    if (isCustomBasemapRequest)
-        basemapUrl = m_customBasemapUrl;
-    else if (m_mapIds[spec.mapId()] == PIX4D_STREETS)
-        basemapUrl = MAPTILER_STREETS_URL;
-    else // if (m_mapIds[spec.mapId()] == PIX4D_SATELLITE)
-        basemapUrl = MAPTILER_SATELLITE_URL;
 
-    basemapUrl = basemapUrl.replace("{x}", x);
-    basemapUrl = basemapUrl.replace("{y}", y);
-    basemapUrl = basemapUrl.replace("{z}", z);
-    basemapUrl = basemapUrl.replace("{s}", "{sabc}");
+    QUrl tileUrl;
+    if (!isCustomBasemapRequest)
+    {
+        tileUrl = QUrl(QStringLiteral("https://api.mapbox.com/styles/v1/cloudpix4d/")
+                + ((spec.mapId() >= m_mapIds.size()) ? PIX4D_STREET : m_mapIds[spec.mapId()])
+                + QLatin1String("/tiles/256/")
+                + QString::number(spec.zoom())
+                + QLatin1Char('/')
+                + QString::number(spec.x())
+                + QLatin1Char('/')
+                + QString::number(spec.y())
+                + ((m_scaleFactor > 1) ? (QLatin1Char('@') + QString::number(m_scaleFactor) + QLatin1Char('x')) : QString())
+                + QLatin1Char('?')
+                + QStringLiteral("access_token=")
+                + m_accessToken);
+    }
+    else
+    {
+        const QString x = QString::number(spec.x());
+        const QString y = QString::number(spec.y());
+        const QString z = QString::number(spec.zoom());
+        QString q, r, bbox, invY, wmsVersion;
+        QStringList subdomains;
 
-    if (basemapUrl.contains("{-y}"))
-    {
-        invY = QString::number((1 << spec.zoom()) - spec.y() - 1);
-        basemapUrl = basemapUrl.replace("{-y}", invY);
-    }
+        auto basemapUrl = m_customBasemapUrl;
+        basemapUrl = basemapUrl.replace("{x}", x);
+        basemapUrl = basemapUrl.replace("{y}", y);
+        basemapUrl = basemapUrl.replace("{z}", z);
+        basemapUrl = basemapUrl.replace("{s}", "{sabc}");
 
-    if (basemapUrl.contains("{q}"))
-    {
-        q = tileToQuad(spec);
-        basemapUrl = basemapUrl.replace("{q}", q);
-    }
-
-    if (basemapUrl.contains("{r}"))
-    {
-        r = m_scaleFactor > 1 ? QLatin1Char('@') + QString::number(m_scaleFactor) + QLatin1String("x") : "";
-        basemapUrl = basemapUrl.replace("{r}", r);
-    }
-
-    if (basemapUrl.contains("{bbox4326}"))
-    {
-        // Version 1.3 and higher of WMS urls uses latitude first
-        const int versionIndex = basemapUrl.toLower().indexOf("version=");
-        wmsVersion = versionIndex >= 0 ? basemapUrl.mid(versionIndex + 8, 3) : "0.0";
-        bbox = bbox4326ToString(spec, wmsVersion.toDouble() < 1.3);
-        basemapUrl = basemapUrl.replace("{bbox4326}", bbox);
-    }
-    else if (basemapUrl.contains("{bbox4326_lonlat}"))
-    {
-        bbox = bbox4326ToString(spec, true);
-        basemapUrl = basemapUrl.replace("{bbox4326_lonlat}", bbox);
-    }
-    else if (basemapUrl.contains("{bbox4326_latlon}"))
-    {
-        bbox = bbox4326ToString(spec, false);
-        basemapUrl = basemapUrl.replace("{bbox4326_latlon}", bbox);
-    }
-    else if (basemapUrl.contains("{bbox3857}"))
-    {
-        bbox = bbox3857ToString(spec);
-        basemapUrl = basemapUrl.replace("{bbox3857}", bbox);
-    }
-
-    int startIndex = basemapUrl.indexOf(QLatin1String("{s"));
-    while (startIndex != -1)
-    {
-        const int endIndex = basemapUrl.indexOf(QLatin1Char('}'), startIndex);
-        if (endIndex != -1)
+        if (basemapUrl.contains("{-y}"))
         {
-            const int count = endIndex - startIndex + 1;
-            const auto value = basemapUrl.mid(startIndex + 2, std::max(count - 3, 0));
-            subdomains.push_back(replaceSubdomain(spec, value));
-            basemapUrl.replace(startIndex, count, subdomains.back());
-            startIndex = basemapUrl.indexOf(QLatin1String("{s"));
+            invY = QString::number((1 << spec.zoom()) - spec.y() - 1);
+            basemapUrl = basemapUrl.replace("{-y}", invY);
         }
-        else
+
+        if (basemapUrl.contains("{q}"))
         {
-            if (m_enableLogging)
+            q = tileToQuad(spec);
+            basemapUrl = basemapUrl.replace("{q}", q);
+        }
+
+        if (basemapUrl.contains("{r}"))
+        {
+            r = m_scaleFactor > 1 ? QLatin1Char('@') + QString::number(m_scaleFactor) + QLatin1String("x") : "";
+            basemapUrl = basemapUrl.replace("{r}", r);
+        }
+
+        if (basemapUrl.contains("{bbox4326}"))
+        {
+            // Version 1.3 and higher of WMS urls uses latitude first
+            const int versionIndex = basemapUrl.toLower().indexOf("version=");
+            wmsVersion = versionIndex >= 0 ? basemapUrl.mid(versionIndex + 8, 3) : "0.0";
+            bbox = bbox4326ToString(spec, wmsVersion.toDouble() < 1.3);
+            basemapUrl = basemapUrl.replace("{bbox4326}", bbox);
+        }
+        else if (basemapUrl.contains("{bbox4326_lonlat}"))
+        {
+            bbox = bbox4326ToString(spec, true);
+            basemapUrl = basemapUrl.replace("{bbox4326_lonlat}", bbox);
+        }
+        else if (basemapUrl.contains("{bbox4326_latlon}"))
+        {
+            bbox = bbox4326ToString(spec, false);
+            basemapUrl = basemapUrl.replace("{bbox4326_latlon}", bbox);
+        }
+        else if (basemapUrl.contains("{bbox3857}"))
+        {
+            bbox = bbox3857ToString(spec);
+            basemapUrl = basemapUrl.replace("{bbox3857}", bbox);
+        }
+
+        int startIndex = basemapUrl.indexOf(QLatin1String("{s"));
+        while (startIndex != -1)
+        {
+            const int endIndex = basemapUrl.indexOf(QLatin1Char('}'), startIndex);
+            if (endIndex != -1)
             {
-                qCritical() << "Basemap custom URL invalid {";
+                const int count = endIndex - startIndex + 1;
+                const auto value = basemapUrl.mid(startIndex + 2, std::max(count - 3, 0));
+                subdomains.push_back(replaceSubdomain(spec, value));
+                basemapUrl.replace(startIndex, count, subdomains.back());
+                startIndex = basemapUrl.indexOf(QLatin1String("{s"));
             }
-            break;
+            else
+            {
+                if (m_enableLogging)
+                {
+                    qCritical() << "Basemap custom URL invalid {";
+                }
+                break;
+            }
         }
-    }
 
-    if (m_enableLogging)
-    {
-        const QString provider = QUrl(basemapUrl).host();
-        QString urlDetails = provider +
-            " {x}=" + x +
-            " {y}=" + y +
-            " {z}=" + z +
-            (!q.isEmpty() ? " {q}=" + q : "") +
-            (!r.isEmpty() ? " {r}=" + r : "") +
-            (!invY.isEmpty() ? " {-y}=" + invY : "") +
-            (!subdomains.isEmpty() ? " {s}=" + subdomains.join(", ") : "") +
-            (!bbox.isEmpty() ? " {bbox}=" + bbox : "") +
-            (!wmsVersion.isEmpty() ? " with version " + wmsVersion : "");
-        qInfo() << "Basemap tile requested" << urlDetails;
-    }
+        if (m_enableLogging)
+        {
+            const QString provider = QUrl(basemapUrl).host();
+            QString urlDetails = provider +
+                " {x}=" + x +
+                " {y}=" + y +
+                " {z}=" + z +
+                (!q.isEmpty() ? " {q}=" + q : "") +
+                (!r.isEmpty() ? " {r}=" + r : "") +
+                (!invY.isEmpty() ? " {-y}=" + invY : "") +
+                (!subdomains.isEmpty() ? " {s}=" + subdomains.join(", ") : "") +
+                (!bbox.isEmpty() ? " {bbox}=" + bbox : "") +
+                (!wmsVersion.isEmpty() ? " with version " + wmsVersion : "");
+            qInfo() << "Basemap tile requested" << urlDetails;
+        }
 
-    tileUrl = QUrl(basemapUrl);
-    
-    if (!m_query.isEmpty())
-        tileUrl.setQuery(m_query);
+        tileUrl = QUrl(basemapUrl);
+    }
 
     request.setUrl(tileUrl);
+
     return new QGeoMapReplyMapbox(m_networkManager->get(request), spec, m_replyFormat, m_enableLogging);
 }
 

--- a/src/qgeotilefetchermapbox.h
+++ b/src/qgeotilefetchermapbox.h
@@ -6,7 +6,6 @@
 
 #include <qlist.h>
 #include <QtLocation/private/qgeotilefetcher_p.h>
-#include <QUrlQuery>
 
 QT_BEGIN_NAMESPACE
 
@@ -19,9 +18,11 @@ class QGeoTileFetcherMapbox : public QGeoTileFetcher
 
 public:
     // The list of map style names:
-    static constexpr const char* PIX4D_STREETS = "Streets";
-    static constexpr const char* PIX4D_SATELLITE = "Satellite";
-    static constexpr const char* PIX4D_CUSTOM = "Custom";
+    // The two values below are part of url allowing to fetch corresponsing mapbox tiles
+    static constexpr const char* PIX4D_STREET = "ck8zz9gpq0vty1ip30bji3b5a";
+    static constexpr const char* PIX4D_STREETS_SATELLITE = "ck8zzfxb30vwp1jo04yktjtbg";
+    // name for custom basemap tiles requests
+    static constexpr const char* PIX4D_CUSTOM = "custom";
 
 public:
     QGeoTileFetcherMapbox(int scaleFactor, bool enableLogging, const QString& customBasemapUrl, QGeoTiledMappingManagerEngine *parent);
@@ -29,7 +30,7 @@ public:
     void setUserAgent(const QByteArray &userAgent);
     void setMapIds(const QList<QString> &mapIds);
     void setFormat(const QString &format);
-    void setAdditionalParameters(const QVariantMap& parameters);
+    void setAccessToken(const QString &accessToken);
 
 private:
     QGeoTiledMapReply *getTileImage(const QGeoTileSpec &spec) override;
@@ -38,11 +39,11 @@ private:
     QByteArray m_userAgent;
     QString m_format;
     QString m_replyFormat;
+    QString m_accessToken;
     QList<QString> m_mapIds;
     int m_scaleFactor;
     bool m_enableLogging{false};
     QString m_customBasemapUrl;
-    QUrlQuery m_query;
 };
 
 QT_END_NAMESPACE

--- a/src/qmapboxcommon.h
+++ b/src/qmapboxcommon.h
@@ -10,9 +10,6 @@
 
 QT_BEGIN_NAMESPACE
 
-static const QString MAPTILER_SATELLITE_URL = QStringLiteral("https://api.maptiler.com/maps/hybrid/{z}/{x}/{y}.jpg");
-static const QString MAPTILER_STREETS_URL = QStringLiteral("https://api.maptiler.com/maps/streets-v2/{z}/{x}/{y}.png");
-
 static const QString mapboxTilesApiPath = QStringLiteral("http://api.tiles.mapbox.com/v4/");
 
 // https://www.mapbox.com/api-documentation/#geocoding
@@ -25,16 +22,6 @@ static const QString mapboxDirectionsApiPath = QStringLiteral("https://api.mapbo
 static const QByteArray mapboxDefaultUserAgent = QByteArrayLiteral("Qt Location based application");
 
 static const qreal mapboxDefaultRadius = 50000;
-
-const QStringList NON_QUERY_PARAMETER_KEYS{QStringLiteral("enable_logging"),
-    QStringLiteral("maximum_zoom_level"),
-    QStringLiteral("no_map_tiles"),
-    QStringLiteral("custom_basemap_url"),
-    QStringLiteral("highdpi_tiles"),
-    QStringLiteral("useragent"),
-    QStringLiteral("format"),
-    QStringLiteral("cache_directory"),
-};
 
 class QMapboxCommon
 {


### PR DESCRIPTION
Reverts Pix4D/pix4d-qt-basemap-plugin#23

stable/2.0.0 shouldn't use MapTiler because we still need this for PIX4Dfields 2.8.2 patch release.
For MapTiler, we will create new branch stable/2.1.0