### PR TITLE
Update MapBox plugin URL, remove MapBox map type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,9 @@ and Custom tiles (provided via custom basemap url) can be done without plugin [r
 
 ### Removed
 - MapBox default tile URLs in QGeoTileFetcherMapbox
+
+
+## QtBasemapPlugin 2.1.0-1
+
+### Changed
+- Update MapBox plugin URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,4 @@ and Custom tiles (provided via custom basemap url) can be done without plugin [r
 
 ### Changed
 - Update MapBox plugin URL
+- Replace MapBox map type name to general map type name for map tile caching

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,9 +4,9 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '2.1.0-0'
+    version = '2.1.0-1'
     license = 'LGPL3'
-    url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.7.1'
+    url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.7.3'
     description = 'Qt GeoServices plugin for basemaps including MapBox'
     settings = 'os', 'compiler', 'build_type', 'arch'
     generators = 'cmake'

--- a/src/qgeofiletilecachemapbox.cpp
+++ b/src/qgeofiletilecachemapbox.cpp
@@ -12,7 +12,7 @@ QGeoFileTileCacheMapbox::QGeoFileTileCacheMapbox(const QList<QGeoMapType> &mapTy
                                                  QObject *parent)
     :QGeoFileTileCache(directory, parent), 
     m_enableLogging(enableLogging), 
-    m_hasCacheDirectory(!directory.isEmpty()), 
+    m_hasCacheDirectory(!directory.isEmpty()),
     m_mapTypes(mapTypes)
 {
     m_scaleFactor = qBound(1, scaleFactor, 2);
@@ -64,11 +64,10 @@ QGeoTileSpec QGeoFileTileCacheMapbox::filenameToTileSpec(const QString &filename
     // @See QGeoFileTileCacheMapBox for more information for this function
     // General scheme is: plugin_name - map_type - zoom - x - y - @scale.png
     // For now the cached tiles names look like this: 
-    //   basemap_pix4d_100-ck8zzfxb30vwp1jo04yktjtbg-13-4401-2685-@2x.png or
-    //   basemap_pix4d_100-ck8zz9gpq0vty1ip30bji3b5a-16-35208-21496-@1x.png
+    //   basemap_pix4d_100-satellite-11-1091-655-@2x.png or
+    //   basemap_pix4d_100-streets-16-35012-20990-@2x.png
     // basemap_pix4d_100 = plugin name
-    // ck8zzfxb30vwp1jo04yktjtbg = streets-satellite type map
-    // ck8zz9gpq0vty1ip30bji3b5a = street type map
+    // Satellite or Streets = map type name
     // 13 = zoom
     // 4401-2685 = x, y
 
@@ -91,10 +90,10 @@ QGeoTileSpec QGeoFileTileCacheMapbox::filenameToTileSpec(const QString &filename
         return QGeoTileSpec();
     }
 
-    // name = mapbox_pix4d_100-ck8zzfxb30vwp1jo04yktjtbg-13-4401-2685-@2x (no extension)
+    // name = basemap_pix4d_100-streets-16-35012-20990-@2x (no extension)
     const QString name = parts.at(0);
     const QStringList fields = name.split('-');
-
+    
     // must be at least 6 different fields
     if (fields.length() < 6)
     {

--- a/src/qgeotilefetchermapbox.h
+++ b/src/qgeotilefetchermapbox.h
@@ -19,9 +19,9 @@ class QGeoTileFetcherMapbox : public QGeoTileFetcher
 
 public:
     // The list of map style names:
-    static constexpr const char* PIX4D_STREETS = "Streets";
-    static constexpr const char* PIX4D_SATELLITE = "Satellite";
-    static constexpr const char* PIX4D_CUSTOM = "Custom";
+    static constexpr const char* PIX4D_STREETS = "streets";
+    static constexpr const char* PIX4D_SATELLITE = "satellite";
+    static constexpr const char* PIX4D_CUSTOM = "custom";
 
 public:
     QGeoTileFetcherMapbox(int scaleFactor, bool enableLogging, const QString& customBasemapUrl, QGeoTiledMappingManagerEngine *parent);


### PR DESCRIPTION
- Replaced map type names from MapBox to MapTiler in `QGeoFileTileCacheMapbox.cpp`
- Updated MapBox plugin URL