### PR TITLE
RAG-10274: Reduce basemap tile fetch requests

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '2.1.0-1'
+    version = '2.1.0-2'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.7.3'
     description = 'Qt GeoServices plugin for basemaps including MapBox'

--- a/src/qgeofiletilecachemapbox.cpp
+++ b/src/qgeofiletilecachemapbox.cpp
@@ -1,7 +1,9 @@
 // Copyright (C) 2016 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+#include "qgeotilefetchermapbox.h"
 #include "qgeofiletilecachemapbox.h"
+
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QDir>
 
@@ -30,6 +32,18 @@ QString QGeoFileTileCacheMapbox::tileSpecToFilename(const QGeoTileSpec &spec, co
 {
     if (!m_hasCacheDirectory)
     {
+        if (m_enableLogging)
+        {
+            qWarning() << "GeoFileTileCache: No cache directory.";
+        }
+        return QString();
+    }
+    if (m_mapTypes[spec.mapId()].name() == QGeoTileFetcherMapbox::PIX4D_CUSTOM)
+    {
+        if (m_enableLogging)
+        {
+            qInfo() << "GeoFileTileCache: Do not cache any custom user maps due to legality. The read/write error can be ignored.";
+        }
         return QString();
     }
 

--- a/src/qgeofiletilecachemapbox.cpp
+++ b/src/qgeofiletilecachemapbox.cpp
@@ -42,8 +42,11 @@ QString QGeoFileTileCacheMapbox::tileSpecToFilename(const QGeoTileSpec &spec, co
     {
         if (m_enableLogging)
         {
-            qInfo() << "GeoFileTileCache: Do not cache any custom user maps due to legality. The read/write error can be ignored.";
+            qInfo() << "GeoFileTileCache: Do not cache any custom user maps due to legality. The read/write warnings can be ignored.";
         }
+        // Will get the warnings because it returns empty QString
+        // WARNING: qt-msg: QFSFileEngine::open: No file name specified
+        // WARNING: qt-msg: QIODevice::write (QFile, ""): device not open
         return QString();
     }
 

--- a/src/qgeotiledmappingmanagerenginemapbox.cpp
+++ b/src/qgeotiledmappingmanagerenginemapbox.cpp
@@ -164,7 +164,11 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
 
     if (!customBasemapUrl.isEmpty())
     {
-        // Do not cache any custom user maps due to legality
+        // If custom basemap URL is not empty, enable both CacheArea::DiskCache and CacheArea::MemoryCache.
+        // CacheArea::DiskCache is only for default basemaps that can cache in directory as same as when custom basemap URL is empty.
+        // CacheArea::MemoryCache is for custom basemaps that do not cache tile images to files due to legality.
+        // In QGeoFileTileCacheMapbox::tileSpecToFilename(),
+        // tile images of custom basemaps will be skipped saving in cache directory and will use only memory cache.
         setCacheHint(QAbstractGeoTileCache::CacheArea::AllCaches);
     }
 

--- a/src/qgeotiledmappingmanagerenginemapbox.cpp
+++ b/src/qgeotiledmappingmanagerenginemapbox.cpp
@@ -8,6 +8,7 @@
 #include <QtLocation/private/qgeomaptype_p.h>
 #include <QtLocation/private/qgeotiledmap_p.h>
 #include "qgeofiletilecachemapbox.h"
+
 typedef QGeoTiledMap Map;
 
 namespace
@@ -67,10 +68,18 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     cameraCaps.setOverzoomEnabled(true);
     setCameraCapabilities(cameraCaps);
 
-    setTileSize(QSize(256, 256));
+    setTileSize(QSize(512, 512));
     m_noMapTiles = getParameter(parameters, "no_map_tiles");
 
     QList<QGeoMapType> mapTypes;
+    mapTypes << QGeoMapType(QGeoMapType::NoMap,
+                            QGeoTileFetcherMapbox::PIX4D_NONE,
+                            QStringLiteral("None"),
+                            false,
+                            false,
+                            mapTypes.size(),
+                            pluginName,
+                            cameraCaps);
     mapTypes << QGeoMapType(QGeoMapType::SatelliteMapDay,
                             QGeoTileFetcherMapbox::PIX4D_SATELLITE,
                             QStringLiteral("Satellite"),
@@ -91,6 +100,7 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     QString customBasemapUrl;
     getParameter(parameters, "custom_basemap_url", customBasemapUrl);
     if (!customBasemapUrl.isEmpty())
+    {
         mapTypes << QGeoMapType(QGeoMapType::CustomMap,
                                 QGeoTileFetcherMapbox::PIX4D_CUSTOM,
                                 QStringLiteral("Custom"),
@@ -99,7 +109,7 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
                                 mapTypes.size(),
                                 pluginName,
                                 cameraCaps);
-
+    }
 
     if (enableLogging)
     {
@@ -138,26 +148,24 @@ QGeoTiledMappingManagerEngineMapbox::QGeoTiledMappingManagerEngineMapbox(const Q
     tileFetcher->setAdditionalParameters(parameters);
     setTileFetcher(tileFetcher);
 
-    if (customBasemapUrl.isEmpty())
+    // Set up the tile cache
+    QString cacheDirectory;
+    if (!getParameter(parameters, "cache_directory", cacheDirectory))
     {
-        // Set up the tile cache
-        QString cacheDirectory;
-        if (!getParameter(parameters, "cache_directory", cacheDirectory))
-        {
-            cacheDirectory = QAbstractGeoTileCache::baseLocationCacheDirectory() + QLatin1String(pluginName);
-        }
-
-        auto tileCache = new QGeoFileTileCacheMapbox(mapTypes, scaleFactor, enableLogging, cacheDirectory);
-        tileCache->setCostStrategyDisk(QGeoFileTileCache::Unitary);
-        tileCache->setCostStrategyMemory(QGeoFileTileCache::ByteSize);
-        tileCache->setCostStrategyTexture(QGeoFileTileCache::ByteSize);
-        tileCache->setMaxDiskUsage(6000);
-        setTileCache(tileCache);
+        cacheDirectory = QAbstractGeoTileCache::baseLocationCacheDirectory() + QLatin1String(pluginName);
     }
-    else
+
+    auto tileCache = new QGeoFileTileCacheMapbox(mapTypes, scaleFactor, enableLogging, cacheDirectory);
+    tileCache->setCostStrategyDisk(QGeoFileTileCache::Unitary);
+    tileCache->setCostStrategyMemory(QGeoFileTileCache::ByteSize);
+    tileCache->setCostStrategyTexture(QGeoFileTileCache::ByteSize);
+    tileCache->setMaxDiskUsage(6000);
+    setTileCache(tileCache);
+
+    if (!customBasemapUrl.isEmpty())
     {
         // Do not cache any custom user maps due to legality
-        setCacheHint(QAbstractGeoTileCache::CacheArea::MemoryCache);
+        setCacheHint(QAbstractGeoTileCache::CacheArea::AllCaches);
     }
 
     *error = QGeoServiceProvider::NoError;

--- a/src/qgeotilefetchermapbox.cpp
+++ b/src/qgeotilefetchermapbox.cpp
@@ -145,7 +145,7 @@ void QGeoTileFetcherMapbox::setFormat(const QString &format)
     else if (m_format == "jpg70" || m_format == "jpg80" || m_format == "jpg90")
         m_replyFormat = "jpg";
     else
-        qWarning() << "Unknown map format " << m_format;
+        qWarning() << "QGeoTileFetcher: Unknown map format " << m_format;
 }
 
 void QGeoTileFetcherMapbox::setAdditionalParameters(const QVariantMap& parameters)
@@ -173,14 +173,27 @@ QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
     QStringList subdomains;
 
     QString basemapUrl;
-
     const auto mapId = spec.mapId() < m_mapIds.size() ? m_mapIds[spec.mapId()] : "";
-    if ((mapId == PIX4D_CUSTOM) && !m_customBasemapUrl.isEmpty())
-        basemapUrl = m_customBasemapUrl;
-    else if (mapId == PIX4D_SATELLITE)
+    if (mapId == PIX4D_SATELLITE)
+    {
         basemapUrl = MAPTILER_SATELLITE_URL;
-    else // if (mapId == PIX4D_STREETS || mapId == "")
+    }
+    else if (mapId == PIX4D_STREETS)
+    {
         basemapUrl = MAPTILER_STREETS_URL;
+    }
+    else if ((mapId == PIX4D_CUSTOM) && !m_customBasemapUrl.isEmpty())
+    {
+        basemapUrl = m_customBasemapUrl;
+    }
+    else
+    {
+        if (m_enableLogging)
+        {
+            qInfo() << "QGeoTileFetcher: The selected basemap is NONE or the basemap URL is empty. Selected basemap type is " << mapId;
+        }
+        return nullptr;
+    }
 
     basemapUrl = basemapUrl.replace("{x}", x);
     basemapUrl = basemapUrl.replace("{y}", y);
@@ -245,7 +258,7 @@ QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
         {
             if (m_enableLogging)
             {
-                qCritical() << "Basemap custom URL invalid {";
+                qCritical() << "QGeoTileFetcher: Basemap custom URL invalid {";
             }
             break;
         }
@@ -264,7 +277,7 @@ QGeoTiledMapReply *QGeoTileFetcherMapbox::getTileImage(const QGeoTileSpec &spec)
             (!subdomains.isEmpty() ? " {s}=" + subdomains.join(", ") : "") +
             (!bbox.isEmpty() ? " {bbox}=" + bbox : "") +
             (!wmsVersion.isEmpty() ? " with version " + wmsVersion : "");
-        qInfo() << "Basemap tile requested" << urlDetails;
+        qInfo() << "QGeoTileFetcher: Basemap tile requested" << urlDetails;
     }
 
     tileUrl = QUrl(basemapUrl);

--- a/src/qgeotilefetchermapbox.h
+++ b/src/qgeotilefetchermapbox.h
@@ -22,6 +22,7 @@ public:
     static constexpr const char* PIX4D_STREETS = "streets";
     static constexpr const char* PIX4D_SATELLITE = "satellite";
     static constexpr const char* PIX4D_CUSTOM = "custom";
+    static constexpr const char* PIX4D_NONE = "none";
 
 public:
     QGeoTileFetcherMapbox(int scaleFactor, bool enableLogging, const QString& customBasemapUrl, QGeoTiledMappingManagerEngine *parent);


### PR DESCRIPTION
Solution 1. Active tile cache folder to read/write when the user has custom basemap URL. In this case, we will read/write cache dir only for default map types. The custom basemap keep use the memory cache.
Solution 2. Add NONE map type that can handle when the user selects map type to NoMap, the basemapURL will be empty that we can't continue to request tiles.