### PR TITLE
RAG-10274: Update QtBasemapPlugin version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class QtBasemapPluginConan(ConanFile):
     name = 'QtBasemapPlugin'
-    version = '2.1.0-2'
+    version = '2.1.0-3'
     license = 'LGPL3'
     url = 'http://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/geoservices/mapbox?h=6.7.3'
     description = 'Qt GeoServices plugin for basemaps including MapBox'


### PR DESCRIPTION
We updated 2.1.0-2 long time ago and reverted to 2.1.0-1, but the still old 2.1.0-2 is remaining in conan server so we cannot build conan package with same version and recent changes. The new version will create QtBasemapPlugin with recent changes.